### PR TITLE
Allow enabling dev tools from env settings

### DIFF
--- a/config/beyondz.yml
+++ b/config/beyondz.yml
@@ -30,3 +30,4 @@ staging:
 
 production:
   <<: *default_settings
+  dev_tools_enabled: <%= ENV.fetch('DEV_TOOLS_ENABLED') { false } %>


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1174569613518656/f

Summary: We want to be able to turn on `dev_tools_enabled` on Booster Portal so Tess can test. That's not currently allowed in prod environments. This lets us override via an environment variable. We should be careful to turn this back off (via env settings) once Tess is done testing.