### PR TITLE
Stop resizing images!

### DIFF
--- a/public/javascripts/instructure.js
+++ b/public/javascripts/instructure.js
@@ -284,7 +284,6 @@ define([
       $(".user_content.unenhanced:visible")
         .each(function() {
           var $this = $(this);
-          $this.find("img").css('maxWidth', Math.min($content.width(), $this.width()));
           $this.data('unenhanced_content_html', $this.html());
         })
         .find(".enhanceable_content").show()


### PR DESCRIPTION
Task: https://app.asana.com/0/1170776727341290/1174569613518649/f

This piece of Canvas JS resizes images on the fly. I don't know why. 

Note that this PR requires a rebuild of the canvas container, which takes ~15 minutes on my machine. 