### PR TITLE
Fix the error logs getting spammed.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1203,7 +1203,7 @@ class Account < ActiveRecord::Base
     end
   end
 
-  def update_all_update_account_associations
+  def self.update_all_update_account_associations
     Account.root_accounts.active.find_each(&:update_account_associations)
   end
 


### PR DESCRIPTION
In the Booster portal, the worker process was spitting out this error constantly:

```Original error: undefined method `update_all_update_account_associations' for Account(id: integer, name: ... ```

It came from the config/initializers/periodic_jobs.rb call to:
Delayed::Periodic.cron 'Account.update_all_update_account_associations'

I have no clue how this wasn't a problem in Accelerator portal running the same code. Maybe
there were no associations to update. Either way, **this is the same fix found upstream here**:
https://github.com/instructure/canvas-lms/commit/ea4c74320b5e7d87136acf51f6f167580cca2c96

Note: Booster Portal has generated 1.4 million of these errors since we launched it a few weeks ago while
Accelerator Portal only has 13 of these errors. Here is the SQL I ran:
select count(*) from error_reports where message like '%update_all_update_account_associations%';

### Test Plan:
1. run the following and see the errors:
  ./script/delayed_job run
2. With the fix, run it again and see that they go away and that the job runs.