### PR TITLE
Fix course copy.

### DIFF
--- a/gems/canvas_mimetype_fu/lib/canvas_mimetype_fu/mimetype_fu.rb
+++ b/gems/canvas_mimetype_fu/lib/canvas_mimetype_fu/mimetype_fu.rb
@@ -5,7 +5,7 @@ class File
     if file.class == File || file.class == Tempfile
       unless RUBY_PLATFORM.include? 'mswin32'
         # INSTRUCTURE: changed to IO.popen to avoid shell injection attacks when paths include user defined content
-        mime = IO.popen(['file', '--mime', '-br', '--', file.path], &:read).strip
+        mime = IO.popen(['file', '--mime', '--brief', '--raw', '--', file.path], &:read).strip
       else
         mime = extensions[File.extname(file.path).gsub('.','').downcase] rescue nil
       end
@@ -17,7 +17,7 @@ class File
       temp.close
       # INSTRUCTURE: changed to IO.popen to be sane and consistent. This one shouldn't be able to contain a user
       # specified path, but that's no reason to not do things the right way.
-      mime = IO.popen(['file', '--mime', '-br', '--', temp.path], &:read).strip
+      mime = IO.popen(['file', '--mime', '--brief', '--raw', '--', temp.path], &:read).strip
       mime = mime.gsub(/^.*: */,"")
       mime = mime.gsub(/;.*$/,"")
       mime = mime.gsub(/,.*$/,"")


### PR DESCRIPTION
Course Copy was throwing `unknown mime type unknown/unknown` errors.
It was caused by this:

```
file: invalid option -- 'r'
Usage: file [-bchikLlNnprsvz0] [--apple] [--mime-encoding] [--mime-type]
            [-e testname] [-F separator] [-f namefile] [-m magicfiles] file ...
       file -C [-m magicfiles]
       file [--help]
```
Looks like this version of linux or just Docker has a different "file" exe. I found the fix here:
https://github.com/instructure/canvas-lms/commit/74d0262fc02a6bd8de52be4537cc7a378f67a1c2

### Test Plan
- Go to course 1 (aka Content Library), click Settings, click Copy This Course,
  choose all content and let it run. It should successfully copy over the content.