### PR TITLE
Add the ability to switch b/n Booster and Accelerator dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,15 @@ services:
       - ./spec:/app/spec
       - ./db/migrate:/app/db/migrate
       - ./docker-compose:/app/docker-compose
+      - ./public/bz_support.js:/app/public/bz_support.js
+      - ./public/bz_support.css:/app/public/bz_support.css
      # Note: if you try and mount the entire "public" directory as a volume, it will mask the stuff generated inside 
      # the container at build time during compile_assets and you'll get all sorts of "not found" console errors.
     networks:
       - bravendev
     environment:
       RACK_ENV: development
+      AWS_BUCKET: ${AWS_BUCKET}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     depends_on:

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -5,12 +5,13 @@
 # for that server in them and should not be checked in.
 # See this for more info: https://github.com/bkeepers/dotenv#can-i-use-dotenv-in-production
 
-# TODO: Make AWS_BUCKET configurable/add another env var/move this to ~/.env 
-# This value is to run dbrefreshbooster.sh
-# Don't commit this to the actual repo or dbrefresh.sh won't work
-AWS_BUCKET=booster-portal-dev-file-uploads
-AWS_ACCESS_KEY_ID=THIS_VALUE_SHOULD_HAVE_BEEN_PASSED_FROM_YOUR_HOST_AKA_LOCAL_MACHINE
-AWS_SECRET_ACCESS_KEY=THIS_VALUE_SHOULD_HAVE_BEEN_PASSED_FROM_YOUR_HOST_AKA_LOCAL_MACHINE
+# Set this to one of the following in your host shell
+# depending on whether you're working on Booster or Accelerator:
+#AWS_BUCKET=beyondz-dev-canvas-files
+#AWS_BUCKET=booster-portal-dev-file-uploads
+#AWS_ACCESS_KEY_ID=THIS_VALUE_SHOULD_HAVE_BEEN_PASSED_FROM_YOUR_HOST_AKA_LOCAL_MACHINE
+#AWS_SECRET_ACCESS_KEY=THIS_VALUE_SHOULD_HAVE_BEEN_PASSED_FROM_YOUR_HOST_AKA_LOCAL_MACHINE
+
 BZ_BASE_URL=http://canvasweb
 BZ_BITLY_ACCESS_TOKEN=12345689assdfe
 BZ_DOCUSIGN_HOST=TODO

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -5,7 +5,10 @@
 # for that server in them and should not be checked in.
 # See this for more info: https://github.com/bkeepers/dotenv#can-i-use-dotenv-in-production
 
-AWS_BUCKET=beyondz-dev-canvas-files
+# TODO: Make AWS_BUCKET configurable/add another env var/move this to ~/.env 
+# This value is to run dbrefreshbooster.sh
+# Don't commit this to the actual repo or dbrefresh.sh won't work
+AWS_BUCKET=booster-portal-dev-file-uploads
 AWS_ACCESS_KEY_ID=THIS_VALUE_SHOULD_HAVE_BEEN_PASSED_FROM_YOUR_HOST_AKA_LOCAL_MACHINE
 AWS_SECRET_ACCESS_KEY=THIS_VALUE_SHOULD_HAVE_BEEN_PASSED_FROM_YOUR_HOST_AKA_LOCAL_MACHINE
 BZ_BASE_URL=http://canvasweb

--- a/docker-compose/scripts/dbrefreshbooster.sh
+++ b/docker-compose/scripts/dbrefreshbooster.sh
@@ -11,6 +11,7 @@ sleep 5 # wait for canvasdb container to be accepting connections
 aws s3 cp "s3://booster-staging-db-dumps/$dbfilename" - | gunzip | sed -e "
 
   s/https:\/\/stagingplatform.bebraven.org/http:\/\/platformweb:3020/g;
+  s/https:\/\/stagingboosterplatform.braven.org/http:\/\/platformweb:3020/g;
   s/https:\/\/stagingjoin.bebraven.org/http:\/\/joinweb:3001/g;
 
   # Also fix up internal links in assignments to stay on staging as we navigate

--- a/docker-compose/scripts/dbrefreshbooster.sh
+++ b/docker-compose/scripts/dbrefreshbooster.sh
@@ -44,11 +44,10 @@ cat <<EOF | docker-compose exec -T canvasdb psql -U canvas canvas
   -- This is the hashed value of the dev only encryption key used in security.yml
   update settings set value = '40ed0028ef3004ed37cbec550a57bcde82472631' where name = 'encryption_key_hash';
 
-  -- The 'Beyond Z Platform Integration' access token for dev is:
-  -- BEW8ldtbMypKZiCs8EmW2eQXfOoBpfOEwNJXwyvfIKZIpMgQzBfYUugc4V20oFgt
+  -- The 'Braven Platform Client' access token for dev is:
+  -- XAlbyObifoe76wJECtpLDGEvIVViPVklRnhAkWvUFIm8957NSS5eonRn5oYGqb0y 
   -- These are the encrypted values that the above accces token works against:
-  -- TODO: API access will be broken until we fix this
-  -- update access_tokens set crypted_token = 'd3cb10787c10be0c15bd036f1ae502360e4cc7c4', token_hint = 'BEW8l' where id = 2;
+  -- update access_tokens set crypted_token = '38085caa1b4efd6e878bb2ffd786846a58a622e4', token_hint = 'XAlby' where id = 1;
 
   insert into settings (name, value, created_at, updated_at)
   select 'cas_timelimit', '15', NOW(), NOW()

--- a/docker-compose/scripts/dbrefreshbooster.sh
+++ b/docker-compose/scripts/dbrefreshbooster.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+echo "Refreshing your local dev database from the staging db"
+ 
+dbfilename='lms_booster_db_latest.sql.gz'
+
+docker-compose down
+docker volume rm canvas-lms_canvas-db
+docker-compose up -d canvasdb
+sleep 5 # wait for canvasdb container to be accepting connections
+
+aws s3 cp "s3://booster-staging-db-dumps/$dbfilename" - | gunzip | sed -e "
+
+  s/https:\/\/stagingplatform.bebraven.org/http:\/\/platformweb:3020/g;
+  s/https:\/\/stagingjoin.bebraven.org/http:\/\/joinweb:3001/g;
+
+  # Also fix up internal links in assignments to stay on staging as we navigate
+  s/https:\/\/stagingbooster.braven.org/http:\/\/canvasweb:3000/g;
+
+  # If we have links to the kits from the LC playbook, fix that up.
+  s/https:\/\/stagingkits.bebraven.org/http:\/\/kitsweb:3005/g;
+
+  # Also fix up links to custom CSS/JS. Note: we could do this on this row but it's a pain
+  # select id, name, settings from accounts where id = 1;
+  s/https:\/\/s3.amazonaws.com\/canvas-stag-assets/http:\/\/cssjsweb:3004/g;
+
+" | docker-compose exec -T canvasdb psql -U canvas canvas
+if [ $? -ne 0 ]
+then
+ echo "Failed restoring from s3://booster-staging-db-dumps/$dbfilename"
+ echo "Make sure that awscli is installed: pip3 install awscli"
+ echo "Also, make sure and run 'aws configure' and put in your Access Key and Secret."
+ echo "Lastly, make sure your IAM account is in the Developers group. That's where the policy to access this bucket is defined."
+ exit 1;
+fi
+
+# Adjust some settings for dev
+# - Set the dev encryption key hash so that dev passwords are encrypted using a dev value.
+# - Set the dev access token and access token hint, used for other apps to be able to call into the Canvas API.
+# - Make the timeout to wait for the SSO server 15 seconds since dev can be slow, especially on first start.
+# - Disable Canvas analytics which relies on a Cassandra DB. No need for this and it clutter the error log.
+cat <<EOF | docker-compose exec -T canvasdb psql -U canvas canvas
+
+  -- This is the hashed value of the dev only encryption key used in security.yml
+  update settings set value = '40ed0028ef3004ed37cbec550a57bcde82472631' where name = 'encryption_key_hash';
+
+  -- The 'Beyond Z Platform Integration' access token for dev is:
+  -- BEW8ldtbMypKZiCs8EmW2eQXfOoBpfOEwNJXwyvfIKZIpMgQzBfYUugc4V20oFgt
+  -- These are the encrypted values that the above accces token works against:
+  -- TODO: API access will be broken until we fix this
+  -- update access_tokens set crypted_token = 'd3cb10787c10be0c15bd036f1ae502360e4cc7c4', token_hint = 'BEW8l' where id = 2;
+
+  insert into settings (name, value, created_at, updated_at)
+  select 'cas_timelimit', '15', NOW(), NOW()
+  where not exists (select id from settings where name = 'cas_timelimit');
+
+  delete from settings where name = 'enable_page_views';
+EOF
+
+./docker-compose/scripts/restart.sh

--- a/docker-compose/scripts/dbrefreshbooster.sh
+++ b/docker-compose/scripts/dbrefreshbooster.sh
@@ -47,7 +47,7 @@ cat <<EOF | docker-compose exec -T canvasdb psql -U canvas canvas
   -- The 'Braven Platform Client' access token for dev is:
   -- XAlbyObifoe76wJECtpLDGEvIVViPVklRnhAkWvUFIm8957NSS5eonRn5oYGqb0y 
   -- These are the encrypted values that the above accces token works against:
-  -- update access_tokens set crypted_token = '38085caa1b4efd6e878bb2ffd786846a58a622e4', token_hint = 'XAlby' where id = 1;
+  update access_tokens set crypted_token = '38085caa1b4efd6e878bb2ffd786846a58a622e4', token_hint = 'XAlby' where id = 1;
 
   insert into settings (name, value, created_at, updated_at)
   select 'cas_timelimit', '15', NOW(), NOW()

--- a/docker-compose/scripts/docker_compose_run.sh
+++ b/docker-compose/scripts/docker_compose_run.sh
@@ -30,8 +30,8 @@ fi
 cp -a /app/docker-compose/.env /app/.env
 
 echo "Checking if the AWS ENV vars are setup"
-if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-  echo "The AWS ENV vars arent setup. One of the following is empty: AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_BUCKET" ]; then
+  echo "The AWS ENV vars arent setup. One of the following is empty: AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY, AWS_BUCKET=$AWS_BUCKET"
   exit 1
 else
   echo "Ok!"


### PR DESCRIPTION
Note: AWS_BUCKET must now be set in your host shell to the Booster vs Accelerator file bucket. Example in docker-compose/.env