### PR TITLE
Add QTI migration tool dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
       unzip \
       fontforge \
       vim \
+      python-lxml \
   && npm cache clean -f \
   && npm install -g n \
   && n 0.12.14 \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -36,6 +36,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
       unzip \
       fontforge \
       vim \
+      python-lxml \
   && npm cache clean -f \
   && npm install -g n \
   && n 0.12.14 \


### PR DESCRIPTION
There's a bug in the portal that does not allow users to copy courses:

Heres the Asana task: https://app.asana.com/0/1179330853755533/1181690780424489

This PR:
- Add a QTI dependency `python-lxml`. For more info on this: https://github.com/instructure/QTIMigrationTool/wiki