### PR TITLE
Add QTI migration tool setup to docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,12 @@ USER dockeruser
 #RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4 --verbose
 RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4
 
+
+# This sets up the QTI Migration tool. This used to be part of the deploy script
+# in config/deploy. Moving to containers we left this step out
+RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool
+RUN chmod +x ./vendor/QTIMigrationTool/migrate.py
+
 # Copy the files needed for rake canvas:compile_assets to work
 # By explicitly doing only the files needed, rebuilds won't re-run 
 # 'canvas:compile_assets' unless one of these changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4
 
 # This sets up the QTI Migration tool. This used to be part of the deploy script
 # in config/deploy. Moving to containers we left this step out
-RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool && chmod +x ./vendor/QTIMigrationTool/migrate.py
+RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool \
+  && chmod +x ./vendor/QTIMigrationTool/migrate.py
 
 # Copy the files needed for rake canvas:compile_assets to work
 # By explicitly doing only the files needed, rebuilds won't re-run 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,7 @@ RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4
 
 # This sets up the QTI Migration tool. This used to be part of the deploy script
 # in config/deploy. Moving to containers we left this step out
-RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool
-RUN chmod +x ./vendor/QTIMigrationTool/migrate.py
+RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool && chmod +x ./vendor/QTIMigrationTool/migrate.py
 
 # Copy the files needed for rake canvas:compile_assets to work
 # By explicitly doing only the files needed, rebuilds won't re-run 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -65,7 +65,8 @@ RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4
 
 # This sets up the QTI Migration tool. This used to be part of the deploy script
 # in config/deploy. Moving to containers we left this step out
-RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool && chmod +x ./vendor/QTIMigrationTool/migrate.py
+RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool \
+  && chmod +x ./vendor/QTIMigrationTool/migrate.py
 
 # TODO: when copying all the individual files over, the manifest gets too big for Heroku to handle
 # aka: latest: digest: sha256:XXXXXX size: 7655

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -65,8 +65,7 @@ RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4
 
 # This sets up the QTI Migration tool. This used to be part of the deploy script
 # in config/deploy. Moving to containers we left this step out
-RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool
-RUN chmod +x ./vendor/QTIMigrationTool/migrate.py
+RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool && chmod +x ./vendor/QTIMigrationTool/migrate.py
 
 # TODO: when copying all the individual files over, the manifest gets too big for Heroku to handle
 # aka: latest: digest: sha256:XXXXXX size: 7655

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -63,6 +63,11 @@ USER dockeruser
 #RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4 --verbose
 RUN bundle install --path vendor/bundle --without=sqlite mysql --jobs 4
 
+# This sets up the QTI Migration tool. This used to be part of the deploy script
+# in config/deploy. Moving to containers we left this step out
+RUN git clone https://github.com/instructure/QTIMigrationTool.git ./vendor/QTIMigrationTool
+RUN chmod +x ./vendor/QTIMigrationTool/migrate.py
+
 # TODO: when copying all the individual files over, the manifest gets too big for Heroku to handle
 # aka: latest: digest: sha256:XXXXXX size: 7655
 # Heroku only seems to be able to handle manifests smaller than 7K bytes. 


### PR DESCRIPTION
There's a bug in the portal that does not allow users to copy courses:

Heres the Asana task: https://app.asana.com/0/1179330853755533/1181690780424489

This PR:
- Add QTI migration tool setup to docker build process. For more info on this: https://github.com/instructure/QTIMigrationTool/wiki