### PR TITLE
Redirect to home after accepting terms

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1111,25 +1111,28 @@ class ApplicationController < ActionController::Base
   end
 
   def post_terms_accept_url
-    # Can we find a pre-accelerator survey for them? if so, send them there
-    course_id = 0
-    assignment_id = 0
-    @current_user.enrollments.active.each do |enrollment|
-      result = enrollment.course.assignments.where(:title => "Pre-Accelerator Survey")
-      if result.any?
-        if enrollment.course.id > course_id
-          course_id = enrollment.course.id
-          assignment_id = result.first.id
-        end
-      end
-    end
-    if course_id > 1
-      next_url = "/courses/#{course_id}/assignments/#{assignment_id}"
-    else
-      next_url = "/"
-    end
+    # We just want them to go home now
+    return "/"
 
-    return next_url
+    # Can we find a pre-accelerator survey for them? if so, send them there
+    # course_id = 0
+    # assignment_id = 0
+    # @current_user.enrollments.active.each do |enrollment|
+    #   result = enrollment.course.assignments.where(:title => "Pre-Accelerator Survey")
+    #   if result.any?
+    #     if enrollment.course.id > course_id
+    #       course_id = enrollment.course.id
+    #       assignment_id = result.first.id
+    #     end
+    #   end
+    # end
+    # if course_id > 1
+    #   next_url = "/courses/#{course_id}/assignments/#{assignment_id}"
+    # else
+    #   next_url = "/"
+    # end
+
+    # return next_url
   end
 
   def require_reacceptance_of_terms


### PR DESCRIPTION
- We do not want to go to the Pre-Accelerator assignment anymore. The preferred way now is to take the users to homepage after accepting the terms