### PR TITLE
Add underscores to some rating_blank ids

### DIFF
--- a/app/views/shared/_rubric_criterion.html.erb
+++ b/app/views/shared/_rubric_criterion.html.erb
@@ -62,7 +62,7 @@
     <% else %>
       <table class="ratings" style="<%= hidden if rubric && rubric.free_form_criterion_comments %>"><tr>
         <% ratings = (criterion.ratings rescue nil); ratings = nil if ratings && ratings.length < 2  %>
-        <% ratings ||= [OpenObject.new(:id => "blank", :description => t(:full_marks, "Full Marks"), :points => 5), OpenObject.new(:id => "blank_2", :description => t(:no_marks, "No Marks"), :points => 0)] %>
+        <% ratings ||= [OpenObject.new(:id => "blank_", :description => t(:full_marks, "Full Marks"), :points => 5), OpenObject.new(:id => "blank_2_", :description => t(:no_marks, "No Marks"), :points => 0)] %>
         <% ratings.each_index do |idx| %>
           <% rating = ratings[idx]; rating.edge = (idx == 0 || idx == ratings.length - 1) %>
           <td id="rating_<%= rating.id %>" class="rating <%= "edge_rating" if rating.edge %>">


### PR DESCRIPTION
https://app.asana.com/0/1109150244034467/1199198698772544

This change adds underscores to the offending ids. We don't believe this should cause a problem, but are not 100% sure.

**Test Plan:** went to the student page and didn't notice anything amiss. went to SpeedGrader and changed some scores, clicking save, and reloading the page to check that the score was saved.