### PR TITLE
Remove duplicate DOM ids on course show page

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -229,6 +229,8 @@ hi there
           tpb.innerHTML = rs.innerHTML;
           var list = tpb.querySelector(".to-do-list");
           list.innerHTML = taskListHtml;
+          // since content is in the tpb, we need to prevent duplicate DOM ids from showing up
+          rs.innerHTML = "";  
         } else
           tpb.parentNode.removeChild(tpb);
         // moving the buttons to the bottom of the html too so I can float it right


### PR DESCRIPTION
https://app.asana.com/0/1109150244034467/1199198698772542

A couple of ids were showing up more than once in the DOM on a URL like courses/102
The root cause seems to be because there was a right side navigation element that the JavaScript was copying directly into a part of the DOM for the dynamic syllabus. That right side navigation was hidden anyway.

Solution was to make sure after copying the part of the DOM, the source (aka right side nav) was set to "" 

Test Plan: ran the change by Anthony and clicked around to use the dynamic syllabus. also, compared the page before and after and it is identical.