### PR TITLE
Dynamically set module grade on explain grade page

### DIFF
--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -385,6 +385,12 @@ class BzController < ApplicationController
 
     cm = bzg.get_context_module(module_item_id)
     submission = bzg.get_participation_assignment(cm.course, cm).find_or_create_submission(user)
+
+    computed_score = @response_object['total_score'] 
+    if computed_score > submission.score
+      bzg.set_user_grade_for_module(module_item_id, user, computed_score)
+      submission = bzg.get_participation_assignment(cm.course, cm).find_or_create_submission(user)
+    end
     @gradebook_grade = submission.nil? ? nil : submission.grade
   end
 

--- a/lib/tasks/canvas/grades.rake
+++ b/lib/tasks/canvas/grades.rake
@@ -1,6 +1,6 @@
 namespace :canvas do
   namespace :grades do
-    desc 'Alter module grades if the calculated grade is higher'
+    desc 'Find module grades discrepancies when computer is greater than gradebook'
     task :audit_module , [:course_id, :module_item_id] => :environment do |t, args|
 
       course = Course.find args[:course_id]
@@ -24,7 +24,6 @@ namespace :canvas do
             shown_grade: submission.score,
             calcuated: obj['total_score']
           }
-          bzg.set_user_grade_for_module(module_item_id, student, obj['total_score'])
         end
       end
 


### PR DESCRIPTION
https://app.asana.com/0/1109150244034467/1199881533351632

On Explain Grade page, modify Submission row's grade if the computed grade is higher. We are assuming that PM-As and TAs won't ever lower someone's module score compared to what is computed. 

Test Plan: Zoom with Rowan
checked that score does not increase if due date has gone by
also checked that manually lowering Submission.grade and Submission.score will get changed back when visiting Explain Grade page.