### PR TITLE
Encourage Chrome

### DIFF
--- a/app/views/bz/_browser_warning.html.erb
+++ b/app/views/bz/_browser_warning.html.erb
@@ -1,5 +1,4 @@
 <div id="bz-non-supported-browser">
-  You are using an unsupported browser. Work you do right now may not be saved properly.
-  <br /><br />
-  Please try again with a newer web browser.
+  Something went wrong. Work you do right now may not be saved properly.
+  <br><br>
 </div>

--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -363,31 +363,32 @@ function bzRetainedInfoSetup(readonly) {
     // if we get here, that means the browser seems to work and we can hide
     // the unsupported browser warning. let's just be extra safe and show something
     // in case they aren't using a recent version of Chrome
-    var browserRaw = navigator.userAgent;
-    var chromeStart = browserRaw.indexOf("Chrome/");
-    var browserMessage = "";
-
-    if (chromeStart == -1) {
-      browserMessage = "It appears you are not using Google Chrome. Work you do may not be saved properly.";
-    } else {
-      var versionStart = chromeStart + "Chrome/".length;
-      var version = browserRaw.substring(versionStart, versionStart + 2);
-      version = parseInt(version);
-
-      if (version < 88)
-        browserMessage = "Your version of Google Chrome seems outdated. Work you do may not be saved properly.";
-    }
-
     var nsb = document.getElementById("bz-non-supported-browser");
 
     if (nsb) {
+      var browserRaw = navigator.userAgent;
+      var chromeStart = browserRaw.indexOf("Chrome/");
+      var browserMessage = "";
+
+      if (chromeStart == -1) {
+        browserMessage = "It appears you are not using Google Chrome. Work you do may not be saved properly.";
+      } else {
+        var versionStart = chromeStart + "Chrome/".length;
+        var version = browserRaw.substring(versionStart, versionStart + 2);
+        version = parseInt(version);
+
+        if (version < 88)
+          browserMessage = "Your version of Google Chrome seems outdated. Work you do may not be saved properly.";
+      }
+
+
       if (browserMessage.length > 0) {
         nsb.textContent = browserMessage;
         nsb.style.display = "block";
       } else {
         nsb.style.display = "none";
       }
-    } 
+    }
   });
   // old one, w don't need all that info though so cutting it off while batching to optimize network use
   // http.open("GET", "/bz/user_retained_data?name=" + encodeURIComponent(name) + "&value=" + encodeURIComponent(el.value) + "&type=" + el.getAttribute("type"), true);

--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -356,14 +356,38 @@ function bzRetainedInfoSetup(readonly) {
       if(pendingMagicFieldLoads == 0 && !pendingMagicFieldLoadEvent) {
         pendingMagicFieldLoadEvent = true;
         window.requestAnimationFrame(triggerMagicFieldsLoaded);
-        console.log("THE MAGIC HAPPENS");
+        console.log("THE MAGIC HAPPENed");
       }
     }
 
-    // disable the unsupported browser warning since this was successful
+    // if we get here, that means the browser seems to work and we can hide
+    // the unsupported browser warning. let's just be extra safe and show something
+    // in case they aren't using a recent version of Chrome
+    var browserRaw = navigator.userAgent;
+    var chromeStart = browserRaw.indexOf("Chrome/");
+    var browserMessage = "";
+
+    if (chromeStart == -1) {
+      browserMessage = "It appears you are not using Google Chrome. Work you do may not be saved properly.";
+    } else {
+      var versionStart = chromeStart + "Chrome/".length;
+      var version = browserRaw.substring(versionStart, versionStart + 2);
+      version = parseInt(version);
+
+      if (version < 88)
+        browserMessage = "Your version of Google Chrome seems outdated. Work you do may not be saved properly.";
+    }
+
     var nsb = document.getElementById("bz-non-supported-browser");
-    if(nsb)
-      nsb.style.display = "none";
+
+    if (nsb) {
+      if (browserMessage.length > 0) {
+        nsb.textContent = browserMessage;
+        nsb.style.display = "block";
+      } else {
+        nsb.style.display = "none";
+      }
+    } 
   });
   // old one, w don't need all that info though so cutting it off while batching to optimize network use
   // http.open("GET", "/bz/user_retained_data?name=" + encodeURIComponent(name) + "&value=" + encodeURIComponent(el.value) + "&type=" + el.getAttribute("type"), true);


### PR DESCRIPTION
https://app.asana.com/0/1109150244034467/1199909951289499

The previous browser warning message was less actionable and direct. Essentially, if something broke somewhere in the JavaScript, a little bit of code would not get run to hide the browser warning. It was hard to know what to do with a vague message talking about an "unsupported browser". Also, it definitely still allowed usage of Safari despite the fact we know Safari doesn't work well the Portal.

In this change, if something breaks, the yellow warning box indicates the fact that something went wrong and the user should not proceed.

![Screenshot from 2021-02-09 20-26-44](https://user-images.githubusercontent.com/8967352/107451910-41a95100-6b16-11eb-8f71-58ad10ada21a.png)

If it notices that the userAgent isn't Chrome, it'll pop up a different warning message.

![Screenshot from 2021-02-09 20-22-34](https://user-images.githubusercontent.com/8967352/107451959-58e83e80-6b16-11eb-8476-424f8ac5e1c0.png)

And if it notices that the Chrome version isn't recent enough (at least 88), it will suggest updating the browser version.

![Screenshot from 2021-02-09 20-27-36](https://user-images.githubusercontent.com/8967352/107452010-77e6d080-6b16-11eb-8dc2-2f66a2fc9adb.png)

And lastly, it will hide the warning message div if none of the previous checks uncover anything.

**Test Plan:** triggers the right message when using Firefox. will need to try it out on Safari and Edge when it's up on staging.