### PR TITLE
Modify error message for Chrome on iOS

### DIFF
--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -371,8 +371,9 @@ function bzRetainedInfoSetup(readonly) {
       var browserMessage = "";
 
       if (chromeStart == -1) {
-        browserMessage = "It appears you are not using Google Chrome. Work you do right now may not be saved properly.";
-        browserMessage += " Download and use Google Chrome for a better Portal experience.";
+        browserMessage = "It appears you are not using Google Chrome on a Windows, MacOS, Linux, or ChromeOS computer. ";
+        browserMessage += "Work you do right now may not be saved properly. ";
+        browserMessage += "Download and use Google Chrome on one of these devices for a better Portal experience.";
       } else {
         var versionStart = chromeStart + "Chrome/".length;
         var version = browserRaw.substring(versionStart, versionStart + 2);


### PR DESCRIPTION
We know that Chrome on iOS gives us issues. Fortunately, we can detect when someone is using Chrome on iOS. This PR makes it more clear that people should use the Portal on a better supported browser and device.

Test Plan: tried it out with user agent in Chrome set to Chrome for iPad and for iPhone. i verified that the new error message shows up.