### PR TITLE
The browser warning apparently never worked on projects

### DIFF
--- a/public/bz_support.css
+++ b/public/bz_support.css
@@ -126,8 +126,9 @@
   color: black;
   padding: 2em;
   margin: 0px auto;
-
   animation: 15s ease-in 0s 1 nonSupportedBrowserAnimation;
+  top: 150px;
+  left: 150px;
 }
 
 /* } done with the above */


### PR DESCRIPTION
the browser warning saying you're not using a supported browser apparently worked on modules but not on project pages.

test plan: i checked it on modules, projects, and surveys