### PR TITLE
only prompt for one missing field

### DIFF
--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -471,19 +471,11 @@ function validateMagicFields() {
   var list = document.querySelectorAll("#assignment_show .description input[type=text][data-bz-retained], #assignment_show .description input[type=url][data-bz-retained], #assignment_show .description textarea[data-bz-retained]");
   for(var a = 0; a < list.length; a++) {
     if(list[a].value == "" && !bzIsOptionalMagicField(list[a])) {
-      if(firstValidateMagicFieldsTest == null || firstValidateMagicFieldsTest != list[a]) {
-        firstValidateMagicFieldsTest = list[a];
-        alert('You have incomplete fields in this project. Go back and complete them before submitting.');
+      if(confirm("You still have at least 1 incomplete field. Do you want to submit now anyway?")) {
+        return true;
+      } else {
         list[a].focus();
         return false;
-      } else {
-        firstValidateMagicFieldsTest = list[a];
-        if(confirm("You still have an incomplete field. Do you want to submit now anyway?")) {
-          return true;
-        } else {
-          list[a].focus();
-          return false;
-        }
       }
     }
   }


### PR DESCRIPTION
https://bebraven.halp.com/tickets/382

Projects are annoying and confusing for Fellows to submit as there's a warning about empty fields even though those fields are allowed to be empty. This change merely pops up a warning if there's a single empty field and confirms whether they still want to submit or not. If not, it will scroll to the first empty field.

Test Plan: attempted to submit DYC with some empty fields. hit cancel. filled out a field. tried to submit again. hit cancel and watched it scroll to the next one.